### PR TITLE
Create html-preview

### DIFF
--- a/.github/workflows/html-preview.yml
+++ b/.github/workflows/html-preview.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
-          trigger: '@preview'
+          trigger: 'preview'
           reaction: rocket
         
       - name: Get preview url using CircleCI REST API

--- a/.github/workflows/html-preview.yml
+++ b/.github/workflows/html-preview.yml
@@ -1,8 +1,7 @@
 name: HTML-Preview
 
 on:
-  check_suite:
-    types: [completed,]
+  status
 
 jobs:
   report_artifacts:

--- a/.github/workflows/html-preview.yml
+++ b/.github/workflows/html-preview.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Search for trigger keyword preview
         uses: khan/pull-request-comment-trigger@master
         id: check
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
           trigger: '@preview'
           reaction: rocket
-        env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-
+        
       - name: Get preview url using CircleCI REST API
         run: |
           site=`curl -s -H'Circle-Token: ${{ github.secrets.CIRCLE_CI_ACCESS_TOKEN }}' "https://circleci.com/api/v1.1/project/github/joergbrech/Modellbildung-und-Simulation/latest/artifacts?branch=${{ github.ref }}&filter=successful" | grep '0/html/intro.html' | cut -d \" -f4`
@@ -33,5 +33,3 @@ jobs:
         with:
           msg: "You asked for a @preview? [Here you go.](${{ env.site }})"
           check_for_duplicate_msg: false  # OPTIONAL
-
-# To Do: Determine the PR name of the check_suite and comment on PR

--- a/.github/workflows/html-preview.yml
+++ b/.github/workflows/html-preview.yml
@@ -1,18 +1,31 @@
 name: HTML-Preview
 
 on:
-  status
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
 
 jobs:
   report_artifacts:
     runs-on: ubuntu-latest
     name: Report Artifacts
     steps:
-    - name: Get preview url using CircleCI REST API
-      env:
-        JOB_CONTEXT: ${{ toJson(github) }}
-      run: |
-        site=`curl -s -H'Circle-Token: ${{ github.secrets.CIRCLE_CI_ACCESS_TOKEN }}' "https://circleci.com/api/v1.1/project/github/joergbrech/Modellbildung-und-Simulation/latest/artifacts?branch=${{ github.ref }}&filter=successful" | grep '0/html/intro.html' | cut -d \" -f4`
-        echo "::set-env name=PREVIEW_URL::$site"
+      - name: Search for trigger keyword preview
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: '@preview'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Get preview url using CircleCI REST API
+        run: |
+          site=`curl -s -H'Circle-Token: ${{ github.secrets.CIRCLE_CI_ACCESS_TOKEN }}' "https://circleci.com/api/v1.1/project/github/joergbrech/Modellbildung-und-Simulation/latest/artifacts?branch=${{ github.ref }}&filter=successful" | grep '0/html/intro.html' | cut -d \" -f4`
+          echo $site
+          echo "::set-env name=PREVIEW_URL::$site"  
+      - name: Post a comment with the preview url
+        run: echo $site
 
 # To Do: Determine the PR name of the check_suite and comment on PR

--- a/.github/workflows/html-preview.yml
+++ b/.github/workflows/html-preview.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Report Artifacts
     steps:
-      - name: Search for trigger keyword preview
-        uses: khan/pull-request-comment-trigger@master
+      - uses: khan/pull-request-comment-trigger@master
         id: check
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -24,7 +23,8 @@ jobs:
         run: |
           site=`curl -s -H'Circle-Token: ${{ github.secrets.CIRCLE_CI_ACCESS_TOKEN }}' "https://circleci.com/api/v1.1/project/github/joergbrech/Modellbildung-und-Simulation/latest/artifacts?branch=${{ github.ref }}&filter=successful" | grep '0/html/intro.html' | cut -d \" -f4`
           echo $site
-          echo "::set-env name=PREVIEW_URL::$site"  
+          echo "::set-env name=PREVIEW_URL::$site"
+          
       - name: Post a comment with the preview url
         if: steps.check.outputs.triggered == 'true'
         uses: unsplash/comment-on-pr@master

--- a/.github/workflows/html-preview.yml
+++ b/.github/workflows/html-preview.yml
@@ -1,0 +1,19 @@
+name: HTML-Preview
+
+on:
+  check_suite:
+    types: [completed,]
+
+jobs:
+  report_artifacts:
+    runs-on: ubuntu-latest
+    name: Report Artifacts
+    steps:
+    - name: Get preview url using CircleCI REST API
+      env:
+        JOB_CONTEXT: ${{ toJson(github) }}
+      run: |
+        site=`curl -s -H'Circle-Token: ${{ github.secrets.CIRCLE_CI_ACCESS_TOKEN }}' "https://circleci.com/api/v1.1/project/github/joergbrech/Modellbildung-und-Simulation/latest/artifacts?branch=${{ github.ref }}&filter=successful" | grep '0/html/intro.html' | cut -d \" -f4`
+        echo "::set-env name=PREVIEW_URL::$site"
+
+# To Do: Determine the PR name of the check_suite and comment on PR

--- a/.github/workflows/html-preview.yml
+++ b/.github/workflows/html-preview.yml
@@ -12,7 +12,7 @@ jobs:
     name: Report Artifacts
     steps:
       - name: Search for trigger keyword preview
-      - uses: khan/pull-request-comment-trigger@master
+        uses: khan/pull-request-comment-trigger@master
         id: check
         with:
           trigger: '@preview'
@@ -26,6 +26,12 @@ jobs:
           echo $site
           echo "::set-env name=PREVIEW_URL::$site"  
       - name: Post a comment with the preview url
-        run: echo $site
+        if: steps.check.outputs.triggered == 'true'
+        uses: unsplash/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: "You asked for a @preview? [Here you go.](${{ env.site }})"
+          check_for_duplicate_msg: false  # OPTIONAL
 
 # To Do: Determine the PR name of the check_suite and comment on PR


### PR DESCRIPTION
This Github action should run each time someone includes "@preview" in a comment. It uses the CricleCI REST API to get the url to the latest build artifact and posts it as a comment.


https://developer.github.com/v3/activity/events/types/#statusevent

https://github.com/Khan/pull-request-comment-trigger