### PR TITLE
Inserted special content boxes

### DIFF
--- a/content/00_einleitung/02_first_steps/01_matlab_command_window.ipynb
+++ b/content/00_einleitung/02_first_steps/01_matlab_command_window.ipynb
@@ -565,7 +565,8 @@
    "source": [
     "Nein! Es klappt nicht. Die Fehlermeldung gibt schon Auskunft darüber wieso, die Dimensionen der Matrizen passen nicht zusammen. \n",
     "\n",
-    "*Hinweis:* Hier ist der Wortlaut der Octave-Fehlermeldung zu sehen. Matlab gibt an dieser Stelle die folgende Fehlermeldung wieder:\n",
+    ":::{admonition} Hinweis\n",
+    "Hier ist der Wortlaut der Octave-Fehlermeldung zu sehen. Matlab gibt an dieser Stelle die folgende Fehlermeldung wieder:\n",
     "\n",
     "```\n",
     "Error using  * \n",
@@ -574,7 +575,8 @@
     "elementwise multiplication, use '.*'.\n",
     "```\n",
     "\n",
-    "Wir behelfen uns eines Tricks: Ein nachgestelltes Apostroph gibt die transponierte Matrix aus:"
+    "Wir behelfen uns eines Tricks: Ein nachgestelltes Apostroph gibt die transponierte Matrix aus.\n",
+    ":::"
    ]
   },
   {
@@ -746,7 +748,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Quiz:** Wie berechne ich die Gesamtkosten aller Mitarbeiter pro Woche mit nur einer Zeile in Matlab? *Hinweis: Das Ergebnis lautet 5212.5 €.*"
+    "**Quiz:** Wie berechne ich die Gesamtkosten aller Mitarbeiter pro Woche mit nur einer Zeile in Matlab? \n",
+    ":::{admonition} Hinweis\n",
+    "Das Ergebnis lautet 5212.5 €.\n",
+    ":::"
    ]
   },
   {
@@ -1355,7 +1360,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   },
   "livereveal": {
    "start_slideshow_at": "selected",

--- a/content/00_einleitung/02_first_steps/01_matlab_command_window.ipynb
+++ b/content/00_einleitung/02_first_steps/01_matlab_command_window.ipynb
@@ -565,7 +565,6 @@
    "source": [
     "Nein! Es klappt nicht. Die Fehlermeldung gibt schon Auskunft darüber wieso, die Dimensionen der Matrizen passen nicht zusammen. \n",
     "\n",
-    ":::{admonition} Hinweis\n",
     "Hier ist der Wortlaut der Octave-Fehlermeldung zu sehen. Matlab gibt an dieser Stelle die folgende Fehlermeldung wieder:\n",
     "\n",
     "```\n",
@@ -575,8 +574,7 @@
     "elementwise multiplication, use '.*'.\n",
     "```\n",
     "\n",
-    "Wir behelfen uns eines Tricks: Ein nachgestelltes Apostroph gibt die transponierte Matrix aus.\n",
-    ":::"
+    "Wir behelfen uns eines Tricks: Ein nachgestelltes Apostroph gibt die transponierte Matrix aus."
    ]
   },
   {

--- a/content/00_einleitung/02_first_steps/01_matlab_command_window.ipynb
+++ b/content/00_einleitung/02_first_steps/01_matlab_command_window.ipynb
@@ -565,6 +565,7 @@
    "source": [
     "Nein! Es klappt nicht. Die Fehlermeldung gibt schon Auskunft darüber wieso, die Dimensionen der Matrizen passen nicht zusammen. \n",
     "\n",
+    ":::{admonition} Hinweis\n",
     "Hier ist der Wortlaut der Octave-Fehlermeldung zu sehen. Matlab gibt an dieser Stelle die folgende Fehlermeldung wieder:\n",
     "\n",
     "```\n",
@@ -574,7 +575,8 @@
     "elementwise multiplication, use '.*'.\n",
     "```\n",
     "\n",
-    "Wir behelfen uns eines Tricks: Ein nachgestelltes Apostroph gibt die transponierte Matrix aus."
+    "Wir behelfen uns eines Tricks: Ein nachgestelltes Apostroph gibt die transponierte Matrix aus.\n",
+    ":::"
    ]
   },
   {
@@ -747,9 +749,9 @@
    "metadata": {},
    "source": [
     "**Quiz:** Wie berechne ich die Gesamtkosten aller Mitarbeiter pro Woche mit nur einer Zeile in Matlab? \n",
-    "```{admonition} Hinweis\n",
+    ":::{admonition} Hinweis\n",
     "Das Ergebnis lautet 5212.5 €.\n",
-    "```"
+    ":::"
    ]
   },
   {

--- a/content/00_einleitung/02_first_steps/01_matlab_command_window.ipynb
+++ b/content/00_einleitung/02_first_steps/01_matlab_command_window.ipynb
@@ -747,9 +747,9 @@
    "metadata": {},
    "source": [
     "**Quiz:** Wie berechne ich die Gesamtkosten aller Mitarbeiter pro Woche mit nur einer Zeile in Matlab? \n",
-    ":::{admonition} Hinweis\n",
+    "```{admonition} Hinweis\n",
     "Das Ergebnis lautet 5212.5 €.\n",
-    ":::"
+    "```"
    ]
   },
   {

--- a/content/00_einleitung/02_first_steps/02_skripte_und_funktionen.ipynb
+++ b/content/00_einleitung/02_first_steps/02_skripte_und_funktionen.ipynb
@@ -22,7 +22,7 @@
    "execution_count": 1,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -55,7 +55,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Hinweis:** *Die allererste Zeile*\n",
+    "```{admonition} Hinweis \n",
+    "*Die allererste Zeile*\n",
     "\n",
     "`%%file myScript.m` \n",
     "\n",
@@ -63,7 +64,8 @@
     "\n",
     "`% Ein kleines Beispielskript`.\n",
     "\n",
-    "Dieses Skript wird mit dem `run` Befehl ausgeführt."
+    "Dieses Skript wird mit dem `run` Befehl ausgeführt.\n",
+    "```"
    ]
   },
   {
@@ -359,7 +361,7 @@
    "execution_count": 12,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -459,7 +461,7 @@
    "execution_count": 15,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -597,7 +599,7 @@
    "execution_count": 18,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -685,7 +687,7 @@
    "execution_count": 20,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -829,7 +831,7 @@
    "execution_count": 1,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -916,7 +918,7 @@
    "execution_count": 27,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -1040,7 +1042,7 @@
    "execution_count": 2,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -1200,7 +1202,7 @@
    "execution_count": 7,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -1404,7 +1406,7 @@
    "execution_count": 41,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -1478,9 +1480,9 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/content/00_einleitung/03_exercises/01_matlab_kennenlernen.ipynb
+++ b/content/00_einleitung/03_exercises/01_matlab_kennenlernen.ipynb
@@ -66,21 +66,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created file '/home/jan/shares/Modellbildung-und-Simulation/content/00_einleitung/fac.m'.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%file fac.m\n",
     "% calculate the factorial of an integer n\n",
@@ -115,21 +107,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created file '/home/jan/shares/Modellbildung-und-Simulation/content/00_einleitung/binomial_coefficient.m'.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%file binomial_coefficient.m\n",
     "function c = binomial_coefficient(n,k)\n",
@@ -146,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +172,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/00_einleitung/03_exercises/04_der_perfekte_wurf.ipynb
+++ b/content/00_einleitung/03_exercises/04_der_perfekte_wurf.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "Man könnte annehmen, dass das (erfolgreiche) Werfen eines Freiwurfs für alle hochbezahlten Basketballstars eine reine Formalität ist. Erstaunlicherweise ist dem nicht so! Während der deutsche NBA Star Dirk Nowitzki in der Saison 2008/09 laut NBA Media Ventures (2009) immerhin eine Trefferquote von 89% hatte, gibt es andere NBA Superstars, die in dieser Hinsicht weniger erfolgreich sind. Ein prominentes Beispiel ist Shaquille O’Neal, der am Ende der Saison 2008/09 gerade einmal eine Trefferquote von 59% hatte, in seiner gesamten Karriere sogar nur eine Quote von 52.4%. Er ist kein Einzelfall: Fast ein Drittel der NBA-Spieler haben beim Freiwurf eine Trefferquote von weniger als 75%. Für uns stellt sich die Frage: Woher kommen diese Unterschiede und ist es eventuell möglich ein Modell zu erstellen, das den ’perfekten Wurf’ wiedergibt?\n",
     "\n",
-	"<figure>\n",
+    "<figure>\n",
     "  <img src=\"images/basketball_title.jpg\" alt=\"Wurf\"/>\n",
     "</figure>"
    ]
@@ -217,7 +217,10 @@
    "metadata": {},
    "source": [
     "#### e) Bank Shots erlaubt!\n",
-    "Erweitern Sie Ihr Programm so, dass der Ball beim Auftreffen am Brett ideal elastisch zurückgestoßen wird. Wie viele Treffer werden nun erzielt ($\\theta = 60^\\circ$)? (Hinweis: Abstand zwischen Korb und Brett beachten!)"
+    "Erweitern Sie Ihr Programm so, dass der Ball beim Auftreffen am Brett ideal elastisch zurückgestoßen wird. Wie viele Treffer werden nun erzielt ($\\theta = 60^\\circ$)? \n",
+    "```{admonition} Hinweis \n",
+    "Beachten Sie den Abstand zwischen Korb und Brett.\n",
+    "```"
    ]
   },
   {
@@ -370,7 +373,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/02_lineare_gleichungen/01_modellierung_einer_highline.ipynb
+++ b/content/02_lineare_gleichungen/01_modellierung_einer_highline.ipynb
@@ -312,7 +312,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/03_gleitkommaarithmetik/01_übungen.ipynb
+++ b/content/03_gleitkommaarithmetik/01_übungen.ipynb
@@ -38,7 +38,9 @@
     " für $x=10^4$ und $x=10^6$. Welches Ergebnis ist richtig?\n",
     " Wie können Sie das Ergebnis umformen, um ein richtiges Ergebnis zu erhalten?\n",
     " \n",
-    " (Hinweis: Vermeiden Sie die Subtraktion von etwa gleich großen Zahlen)"
+    " ```{admonition} Hinweis\n",
+    " Vermeiden Sie die Subtraktion von etwa gleich großen Zahlen)\n",
+    " ```"
    ]
   },
   {
@@ -441,7 +443,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/04_nichtlineare_gleichungen/01_newton-verfahren.ipynb
+++ b/content/04_nichtlineare_gleichungen/01_newton-verfahren.ipynb
@@ -16,13 +16,14 @@
     "\n",
     "![](images/weinglas_funktion.jpg)\n",
     "\n",
-    "Hinweise:\n",
+    "```{admonition} Hinweis\n",
     "1. Um das Volumen auszurechnen, können Sie das Glas auch als Rotationskörper um die x-Achse ansehen. \n",
     "    \n",
     "    $$V=\\pi \\cdot \\int _{a}^{b}(f(x))^{2}\\mathrm {d} x$$\n",
     "2. Die Stammfunktion von $\\arctan(x)$ ist:\n",
     "\n",
     "    $$x\\arctan \\left( x \\right) -1/2\\,\\ln  \\left( 1+{x}^{2} \\right)$$\n",
+    "```\n",
     "\n",
     "Verwenden Sie zur Lösung die MATLAB-Funktion `fzero`.\n",
     "\n",
@@ -64,7 +65,7 @@
     "\n",
     "a) Programmieren Sie das Newton-Verfahren, so dass es wie `fzero` angewendet werden kann. Da die Ableitung der Funktion noch sehr einfach von Hand zu berechnen ist, kann sie dem Programm übergeben werden.\n",
     "\n",
-    "```{note}\n",
+    "```{admonition} Hinweis\n",
     "Machen Sie sich mit *[function handles](https://de.mathworks.com/help/matlab/matlab_prog/creating-a-function-handle.html)* und *[anonymous functions](https://www.mathworks.com/help/matlab/matlab_prog/anonymous-functions.html)* in Matlab vertraut.\n",
     "```"
    ]
@@ -156,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{note}\n",
+    "```{admonition} Hinweis\n",
     "- Sie können Ihr Programm in der Aufgabe {ref}`bierschaum_newton` wiederverwenden. Speichern Sie Ihre Lösung also bestenfalls nach der Fertigstellung ab.\n",
     "- Implementieren Sie eine Schleife über die Spalten der Jacobi-Matrix, pro Spalte müssen Sie einen Differenzenquotienten bilden.\n",
     "- Ihr Programm sollte mit $n+1$ Funktionsaufrufen von `F` auskommen.\n",
@@ -211,7 +212,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{note}\n",
+    "```{admonition} Hinweis\n",
     "Sie können Ihr Programm in der Aufgabe {ref}`bierschaum_newton` wiederverwenden. Speichern Sie Ihre Lösung also bestenfalls nach der Fertigstellung ab.\n",
     "```"
    ]

--- a/content/04_nichtlineare_gleichungen/02_bierschaumzerfall.ipynb
+++ b/content/04_nichtlineare_gleichungen/02_bierschaumzerfall.ipynb
@@ -467,7 +467,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{note}\n",
+    "```{admonition} Hinweis\n",
     "Wenn Sie Ihr Ergebnis aus Aufgaben 2 und 3 wiederverwenden, können Sie die Funktion mit nur 1-2 Zeilen implementieren.* Vermeiden Sie duplizierten Code!\n",
     "```"
    ]

--- a/content/05_interp_approx/03_spline_interpolation.ipynb
+++ b/content/05_interp_approx/03_spline_interpolation.ipynb
@@ -25,10 +25,12 @@
     "Konstruieren sie eine quadratische Splinefunktion durch die Anfangs- und Endpunkte der Teilintervalle (alles Bleistift und Papier!).\n",
     "Bestimmen sie die Koeffizienten der gesuchten Parabeln $z_i(x) = a_i + b_i(x-x_i) + c_i(x-x_i)^2, i \\in [0,2]$.\n",
     "\n",
-    "**Hinweis:** Zur eindeutigen Bestimmung der einzelnen Polynome sind drei Bedingungen notwendig. Zwei sind durch\n",
+    "```{admonition} Hinweis\n",
+    "Zur eindeutigen Bestimmung der einzelnen Polynome sind drei Bedingungen notwendig. Zwei sind durch\n",
     "den Anfangs- und Endpunkt des jeweiligen Intervalls gegeben. Um Knicke im gesamten Spline zu vermeiden\n",
     "wird zusätzlich gefordert, dass die ersten Ableitungen an den Intervallgrenzen übereinstimmen\n",
     "(dritte Bedingung). Welche Randbedingung ist für die erste Ableitung an der Einspannung zu wählen?\n",
+    "```\n",
     "\n",
     "\n",
     "## Aufgabe 2\n",
@@ -41,7 +43,7 @@
    "execution_count": 1,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -125,7 +127,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/07_num_ode/01_simulation_eines_raketenstarts.ipynb
+++ b/content/07_num_ode/01_simulation_eines_raketenstarts.ipynb
@@ -25,7 +25,9 @@
     "\n",
     "Hauptskript Ihrer Simulation. Hier werden die Simulationsparameter festgelegt, die zugrunde liegende gewöhnliche Differentialgleichung gelöst und, je nach Bedarf, eine Animation der Simulation gestartet. \n",
     "\n",
-    "**Hinweis:** *Die Simulation beinhaltet eine Animation und kann deswegen nicht interaktiv auf dieser Seite laufen. Laden Sie sich die Dateien herunter und rechnen Sie lokal auf Ihrem Computer.*"
+    "```{admonition} Hinweis\n",
+    "Die Simulation beinhaltet eine Animation und kann deswegen nicht interaktiv auf dieser Seite laufen. Laden Sie sich die Dateien herunter und rechnen Sie lokal auf Ihrem Computer.\n",
+    "```"
    ]
   },
   {
@@ -708,7 +710,9 @@
     "[Ft, throttle] = F_thrust(t,q)\n",
     "```\n",
     "\n",
-    "**Hinweis:** Bringen Sie zunächst dieses System von Differentialgleichungen auf erste Ordnung\n",
+    "```{admonition} Hinweis\n",
+    "Überführen Sie zunächst dieses System von Differentialgleichungen in ein System erster Ordnung.\n",
+    "```\n",
     "\n",
     "$$\n",
     "\\dot{\\mathbf{q}} = \\textrm{rocket_ode}(t, \\mathbf{q})\n",
@@ -777,9 +781,9 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/content/08_eigenwerte/01_das_qr_verfahren.ipynb
+++ b/content/08_eigenwerte/01_das_qr_verfahren.ipynb
@@ -37,7 +37,7 @@
    "execution_count": 6,
    "metadata": {
     "tags": [
-	 "remove-output"
+     "remove-output"
     ]
    },
    "outputs": [
@@ -69,7 +69,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Hinweis:** Verwenden Sie für die Berechnung der *QR-Zerlegung* die Matlab/Octave-Funktion `qr`.\n",
+    "```{admonition} Hinweis\n",
+    "Verwenden Sie für die Berechnung der *QR-Zerlegung* die Matlab/Octave-Funktion `qr`.\n",
+    "```\n",
     "\n",
     "Überprüfen Sie ob ihrer Funktion die Testfälle in `test_my_eig.m` besteht:"
    ]
@@ -140,7 +142,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/08_eigenwerte/03_schwingungsmoden_eines_eindimensionalen_balkens.ipynb
+++ b/content/08_eigenwerte/03_schwingungsmoden_eines_eindimensionalen_balkens.ipynb
@@ -86,7 +86,9 @@
     "\n",
     "Zur Anschauung einzelner Schwingungsmoden $\\boldsymbol{\\phi}_j$ animiert man sie oft mit einer festen Frequenz $a \\neq \\omega_j$ und ohne Phasenverschiebung.Das folgende Skript berechnet die Eigenfrequenzen und Schwingungsmoden in dem das entsprechende Eigenwertproblem gelöst wird und animiert die Schwingungsmoden. \n",
     "\n",
-    "**Hinweis:** *Wegen der Animation kann das Skript nicht interaktiv ausgeführt werden, laden sie es sich herunter.*"
+    "```{admonition} Hinweis\n",
+    "Wegen der Animation kann das Skript nicht interaktiv ausgeführt werden, laden sie es sich herunter.\n",
+    "```"
    ]
   },
   {
@@ -222,7 +224,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/09_dft/02_filtern_verrauschter_signale.ipynb
+++ b/content/09_dft/02_filtern_verrauschter_signale.ipynb
@@ -18,7 +18,9 @@
     "\n",
     "Verwenden Sie dann einen digitalen Filter um das Rauschen des Signals zu unterdrücken und vergleichen anschließend das gefilterte mit dem unverrauschten Signal S. Wie könnten Sie den Filter konstruieren? Experimentieren Sie mit unterschiedlich stark verrauschten Signalen.\n",
     "\n",
-    "*Hinweis:* Das Signal mit normalverteiltem Rauschen können Sie wie folgt erzeugen:"
+    "```{admonition} Hinweis\n",
+    "Das Signal mit normalverteiltem Rauschen können Sie wie folgt erzeugen:\n",
+    "```"
    ]
   },
   {
@@ -57,7 +59,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/09_dft/03_der_doppler_effekt.ipynb
+++ b/content/09_dft/03_der_doppler_effekt.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# Der Doppler Effekt\n",
     "\n",
-    "*Hinweis*: Der Inhalt dieser Seite lässt sich nicht interaktiv auf dieser Seite ausführen. \n",
+    "```{admonition} Hinweis \n",
+    "Der Inhalt dieser Seite lässt sich nicht interaktiv auf dieser Seite ausführen. \n",
+    "```\n",
     "\n",
     "In [dem folgenden Video](https://www.youtube.com/watch?v=a3RfULw7aAY) ist kurz ein Verkehrsschild zu sehen: Hier ist eine Maximalgeschwindigkeit von 50 mph, bzw. ca. 80 km/h vorgeschrieben.\n",
     "\n",
@@ -164,7 +166,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/09_dft/04_vuvuzela_filter.ipynb
+++ b/content/09_dft/04_vuvuzela_filter.ipynb
@@ -23,7 +23,9 @@
     }
    },
    "source": [
-    "*Hinweis*: Der Inhalt dieser Seite lässt sich nicht interaktiv auf dieser Seite ausführen. \n",
+    "```{admonition} Hinweis\n",
+    "Der Inhalt dieser Seite lässt sich nicht interaktiv auf dieser Seite ausführen. \n",
+    "```\n",
     "\n",
     "**Wir entwickeln einen Vuvuzela-Filter in 5 einfachen Schritten:**"
    ]
@@ -168,7 +170,9 @@
    "source": [
     "Schauen wir uns das Signal im Frequenzraum an. Dazu berechnen wir erstmal die reellen Koeffizenten.\n",
     "\n",
-    "**Hinweis:** *Das dient nur zur Anschauung, wir können auch alles mit den komplexen Koeffizienten machen.*"
+    "```{admonition} Hinweis\n",
+    "Das dient nur zur Anschauung, wir können auch alles mit den komplexen Koeffizienten machen.\n",
+    "```"
    ]
   },
   {
@@ -674,7 +678,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   },
   "livereveal": {
    "scroll": true

--- a/content/10_bvp/01_durchhang_eines_flexiblen_kabels.ipynb
+++ b/content/10_bvp/01_durchhang_eines_flexiblen_kabels.ipynb
@@ -68,7 +68,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In Kapitel {ref}`skripte-und-funktionen` wurde eine Funktion für das Bisektionsverfahren entwickelt. Verwenden Sie diese Funktion in ihrer Implementierung, um das Rad nicht neu erfinden zu müssen."
+    "```{admonition} Hinweis\n",
+    "In Kapitel {ref}`skripte-und-funktionen` wurde eine Funktion für das Bisektionsverfahren entwickelt. Verwenden Sie diese Funktion in ihrer Implementierung, um das Rad nicht neu erfinden zu müssen.\n",
+    "```"
    ]
   },
   {

--- a/content/10_bvp/01_durchhang_eines_flexiblen_kabels.ipynb
+++ b/content/10_bvp/01_durchhang_eines_flexiblen_kabels.ipynb
@@ -68,9 +68,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{admonition} Hinweis\n",
-    "In Kapitel {ref}`skripte-und-funktionen` wurde eine Funktion für das Bisektionsverfahren entwickelt. Verwenden Sie diese Funktion in ihrer Implementierung, um das Rad nicht neu erfinden zu müssen.\n",
-    "```"
+    "In Kapitel {ref}`skripte-und-funktionen` wurde eine Funktion für das Bisektionsverfahren entwickelt. Verwenden Sie diese Funktion in ihrer Implementierung, um das Rad nicht neu erfinden zu müssen."
    ]
   },
   {

--- a/content/10_bvp/01_durchhang_eines_flexiblen_kabels.ipynb
+++ b/content/10_bvp/01_durchhang_eines_flexiblen_kabels.ipynb
@@ -68,7 +68,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Hinweis:** In Kapitel {ref}`skripte-und-funktionen` wurde eine Funktion für das Bisektionsverfahren entwickelt. Verwenden Sie diese Funktion in ihrer Implementierung, um das Rad nicht neu erfinden zu müssen."
+    "```{admonition} Hinweis\n",
+    "In Kapitel {ref}`skripte-und-funktionen` wurde eine Funktion für das Bisektionsverfahren entwickelt. Verwenden Sie diese Funktion in ihrer Implementierung, um das Rad nicht neu erfinden zu müssen.\n",
+    "```"
    ]
   },
   {
@@ -105,7 +107,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/11_pde/01_konvektion_und_diffusion.ipynb
+++ b/content/11_pde/01_konvektion_und_diffusion.ipynb
@@ -87,12 +87,21 @@
     "\n",
     "Visualisieren Sie die Lösung mit Hilfe einer Animation.\n",
     "\n",
-    "**Hinweis:** Beachten Sie bei der Wahl der Diskretisierung die [Courant-Friedrichs-Lewy-Zahl](https://de.wikipedia.org/wiki/CFL-Zahl).\n",
+    "```{admonition} Hinweis \n",
+    "Beachten Sie bei der Wahl der Diskretisierung die [Courant-Friedrichs-Lewy-Zahl](https://de.wikipedia.org/wiki/CFL-Zahl).\n",
+    "```\n",
     "\n",
     "## Zusatzaufgabe\n",
     "\n",
     "Erweitern Sie ihr Programm, so dass der Nutzer eine zeitabhängige (z.B. pulsierende) Fließgeschwindigkeit $c(t)$ vorgeben kann."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -119,7 +128,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -55,8 +55,8 @@ repository:
 #######################################################################################
 # Advanced and power-user settings
 sphinx:
-  extra_extensions          : []  # A list of extra extensions to load by Sphinx.
-  #config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
+  extra_extensions          : ""  # A list of extra extensions to load by Sphinx.
+  config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
   #extensions                : ['sphinxcontrib.bibtex']
   #bibtex_bibfiles           : ['references.bib']
 

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -57,8 +57,6 @@ repository:
 sphinx:
   extra_extensions          : ""  # A list of extra extensions to load by Sphinx.
   config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
-  #extensions                : ['sphinxcontrib.bibtex']
-  #bibtex_bibfiles           : ['references.bib']
 
 #######################################################################################
 # Extended syntax for admonitions (https://jupyterbook.org/content/content-blocks.html#new-style-admonitions)

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -55,8 +55,8 @@ repository:
 #######################################################################################
 # Advanced and power-user settings
 sphinx:
-  extra_extensions          : ""  # A list of extra extensions to load by Sphinx.
-  config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
+  extra_extensions          : []  # A list of extra extensions to load by Sphinx.
+  #config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
   
 #######################################################################################
 # Extended syntax for admonitions (https://jupyterbook.org/content/content-blocks.html#new-style-admonitions)

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -57,3 +57,8 @@ repository:
 sphinx:
   extra_extensions          : ""  # A list of extra extensions to load by Sphinx.
   config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
+  
+#######################################################################################
+# Extended syntax for admonitions (https://jupyterbook.org/content/content-blocks.html#new-style-admonitions)
+parse:
+  myst_extended_syntax: true

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -55,10 +55,10 @@ repository:
 #######################################################################################
 # Advanced and power-user settings
 sphinx:
-  extra_extensions          : ""  # A list of extra extensions to load by Sphinx.
-  config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
-
+  extra_extensions          : []  # A list of extra extensions to load by Sphinx.
+  #config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
+  
 #######################################################################################
 # Extended syntax for admonitions (https://jupyterbook.org/content/content-blocks.html#new-style-admonitions)
-#parse:
-#  myst_extended_syntax: true
+parse:
+  myst_extended_syntax: true

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -57,7 +57,9 @@ repository:
 sphinx:
   extra_extensions          : []  # A list of extra extensions to load by Sphinx.
   #config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
-  
+  extensions                : ['sphinxcontrib.bibtex']
+  bibtex_bibfiles           : ['references.bib']
+
 #######################################################################################
 # Extended syntax for admonitions (https://jupyterbook.org/content/content-blocks.html#new-style-admonitions)
 parse:

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -57,10 +57,10 @@ repository:
 sphinx:
   extra_extensions          : []  # A list of extra extensions to load by Sphinx.
   #config                    : ""  # key-value pairs to directly over-ride the Sphinx configuration
-  extensions                : ['sphinxcontrib.bibtex']
-  bibtex_bibfiles           : ['references.bib']
+  #extensions                : ['sphinxcontrib.bibtex']
+  #bibtex_bibfiles           : ['references.bib']
 
 #######################################################################################
 # Extended syntax for admonitions (https://jupyterbook.org/content/content-blocks.html#new-style-admonitions)
-parse:
-  myst_extended_syntax: true
+#parse:
+#  myst_extended_syntax: true

--- a/content/intro.ipynb
+++ b/content/intro.ipynb
@@ -47,7 +47,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "***Hinweis***: Microsoft Edge und Microsoft Internet Explorer werden nicht unterstützt!"
+    "```{admonition} Achtung\n",
+    ":class: warning\n",
+    "Microsoft Edge und Microsoft Internet Explorer werden nicht unterstützt!\n",
+    "```"
    ]
   },
   {
@@ -89,7 +92,7 @@
    ],
    "mimetype": "text/x-octave",
    "name": "octave",
-   "version": "4.2.2"
+   "version": "5.2.0"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-jupyter-book==0.8.3
-sphinx==3.3.1
+jupyter-book==0.7.2
 octave_kernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-jupyter-book==0.7.2
-sphinxcontrib-bibtex==1.0.0
+jupyter-book==0.8.3
 octave_kernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jupyter-book==0.8.3
+sphinx==3.3.1
 octave_kernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jupyter-book==0.7.2
+jupyter-book==0.8.3
 octave_kernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jupyter-book==0.7.2
+sphinxcontrib-bibtex==1.0.0
 octave_kernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jupyter-book==0.8.3
+sphinxcontrib-bibtex==1.0.0
 octave_kernel


### PR DESCRIPTION
I nested all `Hinweise` into a [special content box](https://jupyterbook.org/content/content-blocks.html#notes-and-warnings).
Jupyter Book implemented a [Markdown friendly style for admonitions](https://jupyterbook.org/content/content-blocks.html#new-style-admonitions) in [0.8.0](https://jupyterbook.org/reference/_changelog.html#new-and-improved), so I switched to 0.8.3.

Fixes #93 
Fixes #99