### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Hereafter we will list our tips and best practices to keep a consistent look to 
 
 Images can be embedded with the following code block. All lines starting with a `:` are optional but help with formatting the book.
 ````
-```{image} image/image.png
+```{image} images/image.png
 :alt: Name of image
 :width: 800px
 :align: center


### PR DESCRIPTION
images are usually stored in a `images` folder, not in `image`

closes #236

# Description

<!-- Add a description of the changes -->

## Checklist

 - [x] This pull request is associated to an issue
 - [x] All used resources use a CC-by-SA license or less and are marked appropriately, see [our contribution guide](CONTRIBUTING.md).
 - [x] All used resources have been added to the list in `[TODO, does not exist yet]`
 - [x] New exercises include learning requirements and learning goals.
