### PR TITLE
Update pip in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,11 @@ jobs:
 
       # Install the packages needed to build our documentation
       # This will depend on your particular package!
-      - run: pip3 install -r requirements.txt
+      - run:
+          name: Install requirements
+          command: |
+            pip3 install --upgrade pip
+            pip3 install -r requirements.txt
 
       # Build the page intermediate HTML files and copy all images to the build directory and check external links
       - run:


### PR DESCRIPTION
# Description

<!-- Add a description of the changes -->
Fixes #361. CI runs in the docker image mtmiller/octave, which comes with Python 3.6 and an outdated pip installation. It turns out that updating pip resolves our CI failure.


## Checklist

 - [x] This pull request is associated to an issue
 - ~~[ ] All used resources use a CC-by-SA license or less and are marked appropriately, see our [contribution guide](https://github.com/joergbrech/Modellbildung-und-Simulation/blob/master/CONTRIBUTING.md).~~
 - ~~[ ] All used resources have been added to [list_of_all_resources.md](https://github.com/joergbrech/Modellbildung-und-Simulation/blob/master/docs/List_of_all_resources.md)~~
 - ~~[ ] New exercises include learning requirements and learning goals.~~
 - ~~[ ] Add @LeaKruehler as reviewer and wait for approval just before merging.~~
