### PR TITLE
Update sync.yml

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,5 +1,24 @@
 name: 'Upstream Sync'
 
+env:
+  # Required, URL to upstream (fork base)
+  UPSTREAM_URL: "https://github.com/hbrs-cse/Modellbildung-und-Simulation.git"
+  # Required, token to authenticate bot, could use ${{ secrets.GITHUB_TOKEN }} 
+  # Over here, we use a PAT instead to authenticate workflow file changes.
+  WORKFLOW_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Optional, defaults to main
+  UPSTREAM_BRANCH: "master"
+  # Optional, defaults to UPSTREAM_BRANCH
+  DOWNSTREAM_BRANCH: ""
+  # Optional fetch arguments
+  FETCH_ARGS: ""
+  # Optional merge arguments
+  MERGE_ARGS: "--allow-unrelated-histories"
+  # Optional push arguments
+  PUSH_ARGS: ""
+  # Optional toggle to spawn time logs (keeps action active) 
+  SPAWN_LOGS: "false" # "true" or "false"
+
 on:
   schedule:
   - cron: '11 11 * * *'
@@ -8,48 +27,29 @@ on:
 jobs:
   master:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: master
-    - name: Sync upstream changes
-      id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
-      with:
-        target_sync_branch: master
-        target_repo_token: ${{ secrets.GITHUB_TOKEN }}
-        upstream_sync_branch: master
-        upstream_sync_repo: hbrs-cse/Modellbildung-und-Simulation
-        # test_mode: true
-        target_branch_push_args: --force
-
-    - name: New commits found
-      if: steps.sync.outputs.has_new_commits == 'true'
-      shell: bash
-      run: echo "New commits to sync were found on master branch"
-        
-  gh_pages:
+      - name: GitHub Sync to Upstream Repository (master)
+        uses: dabreadman/sync-upstream-repo@v1.3.0
+        with: 
+          upstream_repo: ${{ env.UPSTREAM_URL }}
+          upstream_branch: ${{ env.UPSTREAM_BRANCH }}
+          downstream_branch: ${{ env.DOWNSTREAM_BRANCH }}
+          token: ${{ env.WORKFLOW_TOKEN }}
+          fetch_args: ${{ env.FETCH_ARGS }}
+          merge_args: ${{ env.MERGE_ARGS }}
+          push_args: ${{ env.PUSH_ARGS }}
+          spawn_logs: ${{ env.SPAWN_LOGS }}
+  gh-pages:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: gh-pages
-    - name: Sync upstream changes
-      id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
-      with:
-        target_sync_branch: gh-pages
-        target_repo_token: ${{ secrets.GITHUB_TOKEN }}
-        upstream_sync_branch: gh-pages
-        upstream_sync_repo: hbrs-cse/Modellbildung-und-Simulation
-        # test_mode: true
-        target_branch_push_args: --force
-
-    - name: New commits found
-      if: steps.sync.outputs.has_new_commits == 'true'
-      shell: bash
-      run: echo "New commits to sync were found on gh-pages branch"
-
-
+      - name: GitHub Sync to Upstream Repository (gh-pages)
+        uses: dabreadman/sync-upstream-repo@v1.3.0
+        with: 
+          upstream_repo: ${{ env.UPSTREAM_URL }}
+          upstream_branch: "gh-pages"
+          downstream_branch: ${{ env.DOWNSTREAM_BRANCH }}
+          token: ${{ env.WORKFLOW_TOKEN }}
+          fetch_args: ${{ env.FETCH_ARGS }}
+          merge_args: ${{ env.MERGE_ARGS }}
+          push_args: ${{ env.PUSH_ARGS }}
+          spawn_logs: ${{ env.SPAWN_LOGS }}


### PR DESCRIPTION
Using an alternative action ([dabreadman/sync-upstream-repo@v1.3.0](https://github.com/marketplace/actions/sync-and-merge-upstream-repository-with-your-current-repository)), I was able to update the fork, see the results [here](https://github.com/PhiSpel/Modellbildung-und-Simulation-1/actions/runs/3839309334).

Updating the `gh-pages` branch throws an issue merging `README.md` (which are identical across all three forks), but marks the workflow run as successful. So I suppose, it is not that big a deal.